### PR TITLE
feat(position): Adiciona funcionalidade de incremento de posição

### DIFF
--- a/backend/app.ts
+++ b/backend/app.ts
@@ -23,6 +23,7 @@ router.get('/trades/position/:positionId', protect, tradeController.getTradesByP
 router.post('/trades', protect, tradeController.addTrade);
 router.put('/trades/:id', protect, tradeController.updateTrade);
 router.post('/trades/:id/partial-exit', protect, tradeController.createPartialExit);
+router.post('/trades/:id/increment', protect, tradeController.incrementPosition);
 router.delete('/trades/:id', protect, tradeController.deleteTrade);
 
 app.use('/api', router);

--- a/frontend/src/components/PositionIncrementForm.tsx
+++ b/frontend/src/components/PositionIncrementForm.tsx
@@ -1,0 +1,96 @@
+import React, { useState } from 'react';
+import { Button } from './ui/Button';
+import ButtonLoader from './ui/ButtonLoader';
+
+interface PositionIncrementFormProps {
+  onSubmit: (data: { increment_quantity: number; increment_price: number; increment_date: string }) => Promise<void>;
+  onCancel: () => void;
+  currentQuantity: number;
+}
+
+const PositionIncrementForm: React.FC<PositionIncrementFormProps> = ({ onSubmit, onCancel, currentQuantity }) => {
+  const [increment_quantity, setIncrementQuantity] = useState<number | ''>('');
+  const [increment_price, setIncrementPrice] = useState<number | ''>('');
+  const [increment_date, setIncrementDate] = useState<string>(new Date().toISOString().split('T')[0]);
+  const [loading, setLoading] = useState(false);
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    if (!increment_quantity || !increment_price || !increment_date) {
+      alert('Por favor, preencha todos os campos.');
+      return;
+    }
+    if (increment_quantity <= 0) {
+      alert('A quantidade deve ser maior que zero.');
+      return;
+    }
+
+    setLoading(true);
+    try {
+      await onSubmit({
+        increment_quantity: Number(increment_quantity),
+        increment_price: Number(increment_price),
+        increment_date,
+      });
+    } catch (error) {
+        console.error("Error on position increment submission", error);
+    } finally {
+        setLoading(false);
+    }
+  };
+
+  return (
+    <form onSubmit={handleSubmit} className="space-y-4">
+      <div>
+        <label className="block text-sm font-medium text-gray-700 mb-1">
+          Quantidade a Incrementar (Atual: {currentQuantity}) *
+        </label>
+        <input
+          type="number"
+          value={increment_quantity}
+          onChange={(e) => setIncrementQuantity(Number(e.target.value) || '')}
+          placeholder="Ex: 50"
+          className="w-full px-3 py-2 border border-gray-300 rounded-md shadow-sm focus:outline-none focus:ring-2 focus:ring-blue-500"
+          required
+          disabled={loading}
+        />
+      </div>
+      <div className="grid grid-cols-2 gap-4">
+        <div>
+          <label className="block text-sm font-medium text-gray-700 mb-1">Preço de Entrada *</label>
+          <input
+            type="number"
+            step="0.01"
+            value={increment_price}
+            onChange={(e) => setIncrementPrice(Number(e.target.value) || '')}
+            placeholder="0.00"
+            className="w-full px-3 py-2 border border-gray-300 rounded-md shadow-sm focus:outline-none focus:ring-2 focus:ring-blue-500"
+            required
+            disabled={loading}
+          />
+        </div>
+        <div>
+          <label className="block text-sm font-medium text-gray-700 mb-1">Data de Entrada *</label>
+          <input
+            type="date"
+            value={increment_date}
+            onChange={(e) => setIncrementDate(e.target.value)}
+            className="w-full px-3 py-2 border border-gray-300 rounded-md shadow-sm focus:outline-none focus:ring-2 focus:ring-blue-500"
+            required
+            disabled={loading}
+          />
+        </div>
+      </div>
+      <div className="flex justify-end gap-3 pt-4">
+        <Button type="button" variant="outline" onClick={onCancel} disabled={loading}>
+          Cancelar
+        </Button>
+        <Button type="submit" disabled={loading}>
+          {loading ? <ButtonLoader text="Salvando..." /> : 'Confirmar Incremento'}
+        </Button>
+      </div>
+    </form>
+  );
+};
+
+export default PositionIncrementForm; 

--- a/frontend/src/services/tradeService.ts
+++ b/frontend/src/services/tradeService.ts
@@ -21,4 +21,11 @@ export const executePartialExit = (
     `/trades/${tradeId}/partial-exit`,
     exitData
   );
+};
+
+export const incrementPosition = (
+    tradeId: number,
+    incrementData: { increment_quantity: number; increment_price: number; increment_date: string }
+) => {
+    return apiClient.post(`/trades/${tradeId}/increment`, incrementData);
 }; 


### PR DESCRIPTION
Esta funcionalidade permite que o usuário adicione novos lotes a uma posição de trade existente. O sistema recalcula automaticamente o preço médio de entrada e a quantidade total da posição, além de registrar cada incremento como um evento no histórico do trade.

Principais alterações:

Backend:
- Criada a rota `POST /api/trades/:id/increment` para processar os incrementos.
- Implementada a lógica no `tradeController` que:
  - Atualiza o trade principal com a nova quantidade e o novo preço médio.
  - Cria um novo registro de trade para servir como log do incremento, mantendo a rastreabilidade.

Frontend:
- Desenvolvido o novo componente `PositionIncrementForm.tsx`, um formulário dedicado para o usuário inserir os dados do incremento (quantidade, preço, data).
- Adicionado um botão "Incrementar Posição" no `TradeDetailsModal`, que abre o novo formulário.
- A visualização do "Histórico da Posição" foi completamente refeita para exibir de forma clara e cronológica tanto os eventos de saída parcial quanto os de incremento.
- A lógica de sumarização na `DashboardPage` foi ajustada para calcular e exibir corretamente a quantidade inicial, a quantidade em aberto e o status da posição, considerando os incrementos.
- Implementado o gerenciamento de estado e as funções necessárias na `DashboardPage` para controlar o modal de incremento e atualizar a interface do usuário após a operação ser concluída com sucesso.